### PR TITLE
Removing ignore for `*.json` files in gitignore. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,6 @@ cython_debug/
 .pdm-python
 main.py
 *.ipynb
-*.json
 .ruff_cache
 
 .mock_state.txt


### PR DESCRIPTION
The reason is that Hatchling will exclude all JSON files included in the source directory if git ignores it for some reason. NOTE: I tried a few other options to get this to work without updating the git ignore:

1. I updated the patterns for including files in a few ways
2. I tried to force-include them explicitly by path. 

None of these worked, I checked by running `uv build` and inspecting the contects of the sdist directly. every time the config folder was not there. Only after updating the gitignore did it work. 