### PR TITLE
Fix readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 > [!IMPORTANT]
 >
-> Bloqade has been restructured to make room for new features and improvements. Please refer to the [migration guide](https://bloqade.quera.com/dev/home/migration/) for more information.
+> Bloqade has been restructured to make room for new features and improvements. Please refer to the [migration guide](https://queracomputing.github.io/bloqade-analog/latest/home/migration/) for more information.
 
 
 # Welcome to Bloqade -- QuEra's Neutral Atom SDK

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,11 @@
 [![codecov](https://codecov.io/github/QuEraComputing/bloqade-analog/graph/badge.svg?token=4YJFc45Jyl)](https://codecov.io/github/QuEraComputing/bloqade-analog)
 ![CI](https://github.com/QuEraComputing/bloqade-analog/actions/workflows/ci.yml/badge.svg)
 
-> [!IMPORTANT]
->
-> Bloqade has been restructured to make room for new features and improvements. Please refer to the [migration guide](./home/migration/) for more information.
+!!! note
+
+  Bloqade has been restructured to make room for new features and improvements.
+  Please refer to the [migration guide](./home/migration/) for more information.
+
 
 # **Welcome to Bloqade**: QuEra's Neutral Atom SDK
 


### PR DESCRIPTION
The link to the migration guide gives a 404.

Also, I noticed that the rendering of the `[!IMPORTANT]` admonition doesn't seem to work with MkDocs, so I replaced it with a `!!! note`.